### PR TITLE
Add cookies handler & Fix get-cookies JSON response

### DIFF
--- a/internal/tls-client-api/api/api.go
+++ b/internal/tls-client-api/api/api.go
@@ -49,5 +49,12 @@ func DefineRouter(ctx context.Context, config cfg.Config, logger log.Logger) (*a
 
 	d.POST("api/free-session", freeSessionRequestHandler)
 
+	addCookiesHandler, err := NewAddCookiesHandler(ctx, config, logger)
+	if err != nil {
+		return nil, fmt.Errorf("can not create addCookiesHandler: %w", err)
+	}
+
+	d.POST("api/cookies/add", addCookiesHandler)
+
 	return d, nil
 }


### PR DESCRIPTION
feat(api): add AddCookiesHandler and structured JSON response for get-cookies
- Register new endpoint at `api/cookies/add`
- Allow adding cookies to a TLS client session via the API

fix(api): return structured JSON from get-cookies handler
- Remove manual marshaling
- Ensure handler responds with proper structured JSON directly